### PR TITLE
Dockerfile: add requirements and fix path to app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN chmod +x snapshot.sh
 EXPOSE 8000
 
 # Define the command to run your Python application
-CMD ["python", "app.py"]
+CMD ["python", "src/mutantautomate/app.py"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+numpy
+pandas
+requests
+pypdb
+bioservices
+reportlab
+mdtraj
+seaborn
+matplotlib
+fpdf
+Bio
+chardet
+flask


### PR DESCRIPTION
Add missing requirements.txt based on pyproject.toml, and fix the path to the app.

However, running this directly will still run in development mode, which you don't want to put on the internet. You need to setup a production environment as described [here](https://flask.palletsprojects.com/en/3.0.x/deploying/).  Something like gunicorn or waitress are probably fine.